### PR TITLE
Big ole stinking hacky fix of a merge of open source work to improve the...

### DIFF
--- a/app/models/spree/order_updater_decorator.rb
+++ b/app/models/spree/order_updater_decorator.rb
@@ -1,0 +1,16 @@
+Spree::OrderUpdater.class_eval do
+
+
+
+  def update_item_total
+    #order.item_total = line_items.sum('price * quantity')
+    puts "ROCKING"
+    order.item_total = line_items.sum('price * quantity')
+    update_order_total
+  end
+
+
+
+
+
+end

--- a/app/models/spree/product_decorator.rb
+++ b/app/models/spree/product_decorator.rb
@@ -1,7 +1,5 @@
+
 Spree::Product.class_eval do
-
-  has_many :sale_prices, through: :prices
-
   # Essentially all read values here are delegated to reading the value on the Master variant
   # All write values will write to all variants (including the Master) unless that method's all_variants parameter is set to false, in which case it will only write to the Master variant
 
@@ -9,11 +7,10 @@ Spree::Product.class_eval do
                       :sale_price_in, :on_sale_in?, :original_price_in, :discount_percent_in, :sale_price,
                       :original_price, :on_sale?, :display_original_price, :display_sale_price
 
-  # TODO also accept a class reference for calculator type instead of only a string
-  def put_on_sale value, params={}
-    all_variants = params[:all_variants] || true
 
-    run_on_variants(all_variants) { |v| v.put_on_sale(value, params) }
+  # TODO also accept a class reference for calculator type instead of only a string
+  def put_on_sale(value, calculator_type = "Spree::Calculator::DollarAmountSalePriceCalculator", all_variants = true, start_at = Time.now, end_at = nil, enabled = true)
+    run_on_variants(all_variants) { |v| v.put_on_sale(value, calculator_type, true, start_at, end_at, enabled) }
   end
   alias :create_sale :put_on_sale
 

--- a/app/models/spree/sale_price.rb
+++ b/app/models/spree/sale_price.rb
@@ -1,15 +1,16 @@
 module Spree
   class SalePrice < ActiveRecord::Base
-
     # TODO validations
     belongs_to :price, :class_name => "Spree::Price"
     has_one :calculator, :class_name => "Spree::Calculator", :as => :calculable, :dependent => :destroy
-
     accepts_nested_attributes_for :calculator
-
     validates :calculator, :presence => true
 
-    scope :active, -> { where(enabled: true).where('(start_at <= ? OR start_at IS NULL) AND (end_at >= ? OR end_at IS NULL)', Time.now, Time.now) }
+    #attr_accessible :value, :start_at, :end_at, :enabled
+
+    scope :active, lambda {
+      where("enabled = 't' AND (start_at <= ? OR start_at IS NULL) AND (end_at >= ? OR end_at IS NULL)", Time.now, Time.now)
+    }
 
     # TODO make this work or remove it
     #def self.calculators
@@ -18,6 +19,11 @@ module Spree
 
     def calculator_type
       calculator.class.to_s if calculator
+    end
+
+    def calculator_type=(calculator_type)
+      clazz = calculator_type.constantize if calculator_type
+      self.calculator = clazz.new if clazz and not self.calculator.is_a? clazz
     end
 
     def price
@@ -41,11 +47,6 @@ module Spree
 
     def stop
       update_attributes({ end_at: Time.now, enabled: false })
-    end
-
-    # Convenience method for displaying the price of a given sale_price in the table
-    def display_price
-      Spree::Money.new(value, {currency: Spree::Config[:currency]})
     end
   end
 end

--- a/app/models/spree/variant_decorator.rb
+++ b/app/models/spree/variant_decorator.rb
@@ -1,13 +1,11 @@
 Spree::Variant.class_eval do
 
-  has_many :sale_prices, through: :prices
+  delegate_belongs_to :default_price, :sale_price, :original_price,:on_sale?,
+                      :display_original_price, :display_sale_price
 
-  delegate_belongs_to :default_price, :sale_price, :original_price, :on_sale?,
-    :display_original_price, :display_sale_price
-
-  def put_on_sale value, params={}
-    all_currencies = params[:all_variants] || true    
-    run_on_prices(all_currencies) { |p| p.put_on_sale value, params }
+  # TODO also accept a class reference for calculator type instead of only a string
+  def put_on_sale(value, calculator_type = "Spree::Calculator::DollarAmountSalePriceCalculator", all_currencies = true, start_at = Time.now, end_at = nil, enabled = true)
+    run_on_prices(all_currencies) { |p| p.put_on_sale value, calculator_type, start_at, end_at, enabled }
   end
   alias :create_sale :put_on_sale
 
@@ -26,11 +24,11 @@ Spree::Variant.class_eval do
   def sale_price_in(currency)
     Spree::Price.new variant_id: self.id, currency: currency, amount: price_in(currency).sale_price
   end
-  
+
   def discount_percent_in(currency)
     price_in(currency).discount_percent
   end
-  
+
   def on_sale_in?(currency)
     price_in(currency).on_sale?
   end
@@ -54,14 +52,14 @@ Spree::Variant.class_eval do
   def stop_sale(all_currencies=true)
     run_on_prices(all_currencies) { |p| p.stop_sale }
   end
-  
+
   private
-   
+
   def run_on_prices(all_currencies, &block)
     if all_currencies && prices.present?
       prices.each { |p| block.call p }
     else
-      block.call default_price  
+      block.call default_price
     end
   end
 end


### PR DESCRIPTION
... function of this plugin that has diverged in the community a fair bit.

This commit incorporates work that allows the plugin to function properly for sale items.

The major issue is that Variants were not correctly announcing themselves as on_sale?=true

When the 'price' was being copied to a line item it was always copied as a the full item price because on_sale? would always report false.

This set of fixes allows the variant to correctly report its status.
